### PR TITLE
remove imaps

### DIFF
--- a/plugin/a.vim
+++ b/plugin/a.vim
@@ -557,11 +557,8 @@ comm! -nargs=? -bang IHS call AlternateOpenFileUnderCursor("h<bang>", <f-args>)
 comm! -nargs=? -bang IHV call AlternateOpenFileUnderCursor("v<bang>", <f-args>)
 comm! -nargs=? -bang IHT call AlternateOpenFileUnderCursor("t<bang>", <f-args>)
 comm! -nargs=? -bang IHN call AlternateOpenNextFile("<bang>")
-imap <Leader>ih <ESC>:IHS<CR>
 nmap <Leader>ih :IHS<CR>
-imap <Leader>is <ESC>:IHS<CR>:A<CR>
 nmap <Leader>is :IHS<CR>:A<CR>
-imap <Leader>ihn <ESC>:IHN<CR>
 nmap <Leader>ihn :IHN<CR>
 
 "function! <SID>PrintList(theList) 


### PR DESCRIPTION
imap should be used with care, especially where <leader> is involved. I have <Space> as leader key, so the whole insert mode freezes every time I press space, and guess what happens when I type " is" :)